### PR TITLE
User guides/recommendations pages

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,15 +11,23 @@ class UsersController < ApplicationController
     @users = User.where(activated: true).paginate(page: params[:page])
   end
 
-  # rubocop:disable Metrics/AbcSize
   def show
     @user = User.find(params[:id])
-    @recommendations = @user.recommendations.paginate(page: params[:page])
+    @recommendations = @user.recommendations.limit(5)
+    @guides = @user.guides.limit(5)
     activated_user unless current_user?(@user) || current_user.activated?
-    @recommendation = current_user.recommendations.build if current_user?(@user) && current_user.activated?
     redirect_to root_url unless @user.activated? || current_user?(@user)
   end
-  # rubocop:enable Metrics/AbcSize
+
+  def guides
+    @user = User.find(params[:id])
+    @guides = @user.guides.paginate(page: params[:page], per_page: 35)
+  end
+
+  def recommendations
+    @user = User.find(params[:id])
+    @recommendations = @user.recommendations.paginate(page: params[:page], per_page: 35)
+  end
 
   def new
     @user = User.new

--- a/app/views/guides/_guide.html.erb
+++ b/app/views/guides/_guide.html.erb
@@ -1,14 +1,38 @@
-<li class="flex flex-col justify-between bg-inherit">
-  <a href="<%= guide_path guide %>">
-    <div class="p-5 w-full flex flex-col justify-start">
-      <h2 class="font-bold text-2xl m-5"><%= guide.title %></h2>
-      <h3 class="m-5 text-xl"><%= guide.description %></h3>
+<li class="flex flex-col p-5 gap-2 justify-<%= local_assigns[:extra] && extra ? 'start' : 'between' %> bg-inherit <%= 'shadow-lg rounded-lg' if local_assigns[:extra] && extra %>">
+  <% unless local_assigns[:extra] && extra %>
+    <a href="<%= guide_path guide %>">
+  <% end %>
+    <div class="<%= 'p-5' unless local_assigns[:extra] && extra %> w-full gap-3 flex flex-col justify-start">
+      <div class="flex justify-between items-start flex-wrap-reverse md:flex-nowrap">
+        <h2 class="font-bold text-xl"><%= guide.title %></h2>
+        <% if local_assigns[:destination] %>
+          <a class="flex gap-1 items-center" href="<%= destination_path guide.locale %>">
+            <p><%= guide.locale.name %></p>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd" />
+            </svg>
+          </a>
+        <% end %>
+      </div>
+      <h3 class="text-md"><%= guide.description %></h3>
     </div>
-  </a>
-  <div class="m-10 mt-0">
-    <a class="flex" href="<%= user_path guide.user %>">
-      <%= gravatar_for(guide.user, size: 32) %>
-      <p class="ml-2 mt-1"><%= guide.user.name %></p>
+  <% unless local_assigns[:extra] && extra %>
     </a>
-  </div>
+  <% end %>
+  <% unless local_assigns[:no_user] && no_user %>
+    <div class="ml-5">
+      <a class="flex items-center" href="<%= user_path guide.user %>">
+        <%= gravatar_for(guide.user, size: 32) %>
+        <p class="ml-2 mt-1"><%= guide.user.name %></p>
+      </a>
+    </div>
+  <% end %>
+  <% if local_assigns[:extra] && extra %>
+    <a class="border-cerulean-500 mt-4 -ml-2 rounded-md py-1 px-2 w-max text-cerulean-500 border-2 text-sm items-center font-bold flex justify-between" href="<%= guide_path guide %>">
+      More info
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
+      </svg>
+    </a>
+  <% end %>
 </li>

--- a/app/views/recommendations/_recommendation.html.erb
+++ b/app/views/recommendations/_recommendation.html.erb
@@ -1,6 +1,16 @@
 <li class="mt-10 rounded-lg flex flex-col justify-between shadow-lg p-8">
-  <div href="<%= recommendation_path recommendation %>">
-    <h3 class="text-xl font-bold"><%= recommendation.title %></h3>
+  <div>
+    <div class="flex justify-between items-start flex-wrap-reverse md:flex-nowrap">
+      <a href="<%= recommendation_path recommendation %>"><h2 class="font-bold text-xl"><%= recommendation.title %></h2></a>
+      <% if local_assigns[:destination] %>
+        <a class="flex gap-1 items-center" href=""><!-- We haven't created the places controller yet -->
+          <p><%= recommendation.place.name %></p>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd" />
+          </svg>
+        </a>
+      <% end %>
+    </div>
     <div class="mt-2" style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; overflow: hidden;"><%= recommendation.content %></div>
   </div>
   <a class="border-cerulean-500 mt-4 -ml-2 rounded-md py-1 px-2 w-max text-cerulean-500 border-2 text-sm items-center font-bold flex justify-between" href="<%= recommendation_path recommendation %>">

--- a/app/views/users/guides.html.erb
+++ b/app/views/users/guides.html.erb
@@ -1,0 +1,21 @@
+<% provide :title, "Guides - #{@user.name}" %>
+
+<%= render 'shared/main' do %>
+  <%= render 'shared/main_heading' do %>
+    Guides - <%= @user.name %>
+  <% end %>
+  <a class="flex gap-2 items-center my-6 ml-4 font-bold" href="<%= user_path @user %>">
+    <%= gravatar_for @user, size: 32 %>
+    <p><%= @user.name %></p>
+  </a>
+  <% if @guides.any? %>
+    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 my-6">
+      <% @guides.each do |guide| %>
+        <%= render guide, extra: true, no_user: true, destination: true %>
+      <% end %>
+    </div>
+    <%= will_paginate @guides %>
+  <% else %>
+    <p class="font-bold text-lg mt-6">No guides available.</p>
+  <% end %>
+<% end %>

--- a/app/views/users/recommendations.html.erb
+++ b/app/views/users/recommendations.html.erb
@@ -1,0 +1,19 @@
+<% provide :title, "Recommendations - #{@user.name}" %>
+
+<%= render 'shared/main' do %>
+  <%= render 'shared/main_heading' do %>
+    Recommendations - <%= @user.name %>
+  <% end %>
+  <a class="flex gap-2 items-center my-6 ml-4 font-bold" href="<%= user_path @user %>">
+    <%= gravatar_for @user, size: 32 %>
+    <p><%= @user.name %></p>
+  </a>
+  <% if @recommendations.any? %>
+    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 my-6">
+      <%= render @recommendations %>
+    </div>
+    <%= will_paginate @recommendations %>
+  <% else %>
+    <p class="font-bold text-lg mt-6">No guides available.</p>
+  <% end %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, @user.name) %>
 
-<div class="max-w-7xl mx-auto flex">
+<div class="max-w-7xl mx-auto flex flex-wrap lg:flex-nowrap justify-center items-start">
   <%= render 'layouts/sidebar' do %>
     <div class="flex flex-col">
       <div class="rounded-full overflow-hidden w-full mr-4">
@@ -18,13 +18,53 @@
   <% end %>
 
   <div class="pt-5 w-full px-4 sm:pt-6 sm:px-6 md:pt-8 lg:pt-10 lg:px-8 xl:pt-15">
-    <h2 class="text-4xl font-bold mb-5">Your recommendations</h2>
+    <div class="mb-12" id="guides">
+      <h2 class="text-4xl text-center lg:text-left font-bold mb-5">
+        <% if @user == current_user %>
+          Your guides
+        <% else %>
+          Guides for <%= @user.name %>
+        <% end %>
+      </h2>
 
-    <% if @recommendations.any? %>
-      <ol class="recommendations">
-        <%= render @recommendations %>
-      </ol>
-      <%= will_paginate @recommendations %>
-    <% end %>
+      <% if @guides.any? %>
+        <ol class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          <% @guides.each do |guide| %>
+            <%= render guide, extra: true, no_user: true, destination: true %>
+          <% end %>
+          <div class="text-center flex flex-col justify-center items-center font-bold text-xl">
+            <a href="/users/<%= @user.id %>/guides" class="hover:underline my-5">
+              View all
+            </a>
+          </div>
+        </ol>
+      <% else %>
+        <p class="mb-6 text-lg ml-4">No guides available.</p>
+      <% end %>
+    </div>
+    <div id="recommendations">
+      <h2 class="text-4xl text-center lg:text-left font-bold mb-5">
+        <% if @user == current_user %>
+          Your recommendations
+        <% else %>
+          Recommendations for <%= @user.name %>
+        <% end %>
+      </h2>
+
+      <% if @recommendations.any? %>
+        <ol class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <% @recommendations.each do |recommendation| %>
+            <%= render recommendation, destination: true %>
+          <% end %>
+          <div class="text-center flex flex-col justify-center font-bold text-xl">
+            <a href="/users/<%= @user.id %>/recommendations" class="hover:underline my-5">
+              View all
+            </a>
+          </div>
+        </ol>
+      <% else %>
+        <p class="text-lg ml-4">No recommendations available.</p>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,14 @@
 
 Rails.application.routes.draw do
   root   'static_pages#home'
-  get    '/about',   to: 'static_pages#about'
-  get    '/signup',  to: 'users#new'
-  get    '/login',   to: 'sessions#new'
-  post   '/login',   to: 'sessions#create'
-  delete '/logout',  to: 'sessions#destroy'
+  get    '/about',            to: 'static_pages#about'
+  get    '/signup',           to: 'users#new'
+  get    '/login',            to: 'sessions#new'
+  post   '/login',            to: 'sessions#create'
+  delete '/logout',           to: 'sessions#destroy'
+  get    '/users/:id/guides', to: 'users#guides'
+  get    '/users/:id/recommendations',
+                              to: 'users#recommendations'
   resources :locales, only: %i[index show], as: 'destinations', path: '/destinations'
   resources :recommendations
   resources :users

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -102,4 +102,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to root_url
   end
+
+  test 'should get guides' do
+    get "#{root_url}users/#{@non_admin.id}/guides"
+    assert_response :success
+  end
+
+  test 'should get recommendations' do
+    get "#{root_url}users/#{@non_admin.id}/recommendations"
+    assert_response :success
+  end
 end

--- a/test/fixtures/recommendations.yml
+++ b/test/fixtures/recommendations.yml
@@ -26,24 +26,28 @@ orange:
   content: "I just ate an orange!"
   created_at: <%= 10.minutes.ago %>
   user: michael
+  place: one
 
 tau_manifesto:
   title: "The Tau Manifesto"
   content: "Check out the @tauday site by @mhartl: https://tauday.com"
   created_at: <%= 3.years.ago %>
   user: michael
+  place: two
 
 cat_video:
   title: "Sad cats"
   content: "Sad cats are sad: https://youtu.be/PKffm2uI4dk"
   created_at: <%= 2.hours.ago %>
   user: michael
+  place: one
 
 most_recent:
   title: "Testing"
   content: "Writing a short test"
   created_at: <%= Time.zone.now %>
   user: michael
+  place: two
 
 <% 30.times do |n| %>
 micropost_<%= n %>:
@@ -51,4 +55,5 @@ micropost_<%= n %>:
   content: <%= Faker::Lorem.sentence(:word_count => 5) %>
   created_at: <%= 42.days.ago %>
   user: michael
+  place: one
 <% end %>

--- a/test/integration/users_profile_test.rb
+++ b/test/integration/users_profile_test.rb
@@ -17,10 +17,13 @@ class UsersProfileTest < ActionDispatch::IntegrationTest
     assert_select 'h1', text: @user.name
     assert_select 'img.gravatar'
     assert_match @user.recommendations.count.to_s, response.body
-    assert_select 'div.pagination'
-    @user.recommendations.paginate(page: 1).each do |recommendation|
+    assert_select 'div#guides'
+    assert_select 'div#recommendations'
+    @user.guides.limit(5).each do |guide|
+      assert_match guide.description, response.body
+    end
+    @user.recommendations.limit(5).each do |recommendation|
       assert_match recommendation.content, response.body
     end
-    assert_select '[aria-label=Pagination]', count: 1
   end
 end


### PR DESCRIPTION
This updates the `users/show` view with 5 guides, 5 recommendations, and links to view all for each.
This also creates similar pages at `/users/:id/guides` and `/users/:id/recommendations` for the view all links. The lists are paginated.

This also fixes the integration tests that broke in the process of changing the `users/show` page, along with adding new basic tests for the guides and recommendations.

This PR closes issues #4 and #10. 