### PR TITLE
Add line clamp plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "^6.0.0-rc.5",
     "@tailwindcss/forms": "^0.3.2",
+    "@tailwindcss/line-clamp": "^0.3.1",
     "@webpack-cli/serve": "^1.4.0",
     "autoprefixer": "^10.2.5",
     "babel-plugin-macros": "^3.1.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -128,6 +128,7 @@ module.exports = {
         extend: {},
     },
     plugins: [
+        require('@tailwindcss/line-clamp'),
         require('@tailwindcss/forms'),
     ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,6 +1136,11 @@
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
+"@tailwindcss/line-clamp@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.3.1.tgz#4d8441b509b87ece84e94f28a4aa9998413ab849"
+  integrity sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg==
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"


### PR DESCRIPTION
Adds [`@tailwindcss/line-clamp` plugin](https://github.com/tailwindlabs/tailwindcss-line-clamp) to allow us to use `line-clamp-x` classes. 